### PR TITLE
Enable IP forwarding on GCE instances

### DIFF
--- a/instance_checker.rb
+++ b/instance_checker.rb
@@ -119,6 +119,7 @@ class InstanceChecker < Warmer
     new_instance = Google::Apis::ComputeV1::Instance.new(
       name: "travis-job-#{SecureRandom.uuid}",
       machine_type: machine_type.self_link,
+      can_ip_forward: true,
       tags: Google::Apis::ComputeV1::Tags.new({
         items: tags,
       }),


### PR DESCRIPTION
Meant to address https://github.com/travis-ci/travis-ci/issues/9696

This may not be necessary since https://github.com/travis-ci/travis-cookbooks/pull/1018 has been merged, but this is probably a cleaner solution.

How to test it though?

*Hat tip to @joepvd for finding that this property can be set at instance creation time!*